### PR TITLE
Add support for custom error messages by field

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,38 @@ In many cases, you won't need to replace all of the error messages. You'll inste
 Iodine.setErrorMessage('passwordConfirmation', 'Does not match password');
 ```
 
+## Custom Errors by Field
+
+Sometimes it is necessary to define a specific error message for a field, or we need a label for a field that is different from the name of the variable used.
+
+To do this with Iodine just pass an object to the assert method containing the rule as property and the custom error message as value e.g.
+
+```js
+Iodine.assert(value, ['required'], { 'required': 'The "Label" must be present.' });
+```
+
+The same can be done for a multiple field validation
+
+```js
+/**
+ *  let items = {
+ *      name: '',
+ *  }
+ *
+ *  let rules = {
+ *      name: ['required']
+ *  }
+ *
+ *  let errors = {
+ *      name: {
+ *          required: 'The "Label" must be present.'
+ *      }
+ *  }
+ */
+
+Iodine.assert(items, rules, errors);
+```
+
 ### Default field name
 
 Since 'single item checks' don't support field names, Iodine uses the default instead (which is 'Value'). If 'Value' is not suitable, then you can call the `setDefaultFieldName` method and supply an alternative `string` value to use instead e.g.

--- a/README.md
+++ b/README.md
@@ -199,34 +199,32 @@ In many cases, you won't need to replace all of the error messages. You'll inste
 Iodine.setErrorMessage('passwordConfirmation', 'Does not match password');
 ```
 
-## Custom Errors by Field
+### Custom Errors by Field
 
-Sometimes it is necessary to define a specific error message for a field, or we need a label for a field that is different from the name of the variable used.
+Sometimes, it may be necessary to define a specific error message for a field, or you need a label for a field that is different from the name of the variable used.
 
-To do this with Iodine just pass an object to the assert method containing the rule as property and the custom error message as value e.g.
+To achieve this, pass an object to the `assert` method containing the rule as property and the custom error message as a value e.g.
 
 ```js
-Iodine.assert(value, ['required'], { 'required': 'The "Label" must be present.' });
+Iodine.assert(value, ['required'], { 'required' : 'The "Label" must be present.' });
 ```
 
-The same can be done for a multiple field validation
+You can also use the same approach for multiple fields e.g.
 
 ```js
-/**
- *  let items = {
- *      name: '',
- *  }
- *
- *  let rules = {
- *      name: ['required']
- *  }
- *
- *  let errors = {
- *      name: {
- *          required: 'The "Label" must be present.'
- *      }
- *  }
- */
+let items = {
+    name : '',
+};
+
+let rules = {
+    name : ['required']
+};
+
+let errors = {
+    name : {
+        required : 'The "Label" must be present.'
+    }
+};
 
 Iodine.assert(items, rules, errors);
 ```

--- a/src/iodine.js
+++ b/src/iodine.js
@@ -170,7 +170,7 @@ export default class Iodine
      * Determine if the given content matches the given schema.
      *
      */
-    assert(values, schema, errors = null) // Mensagens
+    assert(values, schema, errors = null)
     {
         if (Array.isArray(schema)) {
             return this._validate(values, schema, errors);

--- a/src/iodine.js
+++ b/src/iodine.js
@@ -145,14 +145,16 @@ export default class Iodine
      * @internal.
      *
      */
-    _validate(value, rules)
+    _validate(value, rules, errors = null)
     {
         for (let index in rules = this._prepare(value, rules)) {
             if (! this[`assert${rules[index][1]}`].apply(this, [value, rules[index][2]])) {
                 return {
                     valid : false,
                     rule  : rules[index][0],
-                    error : this._error(rules[index][0]),
+                    error : errors 
+                      ? errors[rules[index][0]]
+                      : this._error(rules[index][0]),
                 };
             }
         }
@@ -168,10 +170,10 @@ export default class Iodine
      * Determine if the given content matches the given schema.
      *
      */
-    assert(values, schema)
+    assert(values, schema, errors = null) // Mensagens
     {
         if (Array.isArray(schema)) {
-            return this._validate(values, schema);
+            return this._validate(values, schema, errors);
         }
 
         let keys = Object.keys(schema);
@@ -180,7 +182,7 @@ export default class Iodine
 
         for (let i = 0; i < keys.length; i++) {
             result.fields[keys[i]] = values.hasOwnProperty(keys[i])
-                ? this._validate(values[keys[i]], schema[keys[i]])
+                ? this._validate(values[keys[i]], schema[keys[i]], errors != null ? errors[keys[i]] : null)
                 : this._missing();
 
             if (! result.fields[keys[i]].valid) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -408,7 +408,7 @@ test('it retrieves formatted error messages for rules', () =>
 
     window.Iodine.setLocale('en-US');
 
-    let hour = new Date(parseInt(time)).getHours();
+    let hour = new Date(parseInt(time)).getHours().toString().padStart(2, '0');
 
     expect(window.Iodine._error('array')).toBe('Value must be an array');
     expect(window.Iodine._error('endsWith')).toBe(`Value must end with '[PARAM]'`);

--- a/tests/test.js
+++ b/tests/test.js
@@ -732,27 +732,27 @@ test('it can add advanced custom rules', () =>
  * Confirm that the 'assert' method works correctly with custom errors by field.
  *
  */
-test('it can add custom errors', () =>
+test('it supports custom errors by field', () =>
 {
     let fail = {
         valid : false,
         rule  : 'required',
         error : 'The "Hello" field is required.',
-    }
+    };
 
     let fields = {
       name: '',
-    }
+    };
 
     let rules = {
       name: ['required']
-    }
+    };
 
     let errors = {
       name: {
         required: 'The "Name" field must be present.'
       }
-    }
+    };
 
     let failMultiple = {
       valid  : false,
@@ -765,9 +765,6 @@ test('it can add custom errors', () =>
       },
     };
 
-    expect(window.Iodine.assert('', ['required'], {
-      'required': 'The "Hello" field is required.'
-    })).toStrictEqual(fail)
-
-    expect(window.Iodine.assert(fields, rules, errors)).toStrictEqual(failMultiple)
+    expect(window.Iodine.assert('', ['required'], { 'required': 'The "Hello" field is required.' })).toStrictEqual(fail);
+    expect(window.Iodine.assert(fields, rules, errors)).toStrictEqual(failMultiple);
 });

--- a/tests/test.js
+++ b/tests/test.js
@@ -727,3 +727,47 @@ test('it can add advanced custom rules', () =>
     expect(window.Iodine._error('equals:2')).toBe("Value must be equal to '2'");
     expect(window.Iodine._error('equals', 2)).toBe("Value must be equal to '2'");
 });
+
+/**
+ * Confirm that the 'assert' method works correctly with custom errors by field.
+ *
+ */
+test('it can add custom errors', () =>
+{
+    let fail = {
+        valid : false,
+        rule  : 'required',
+        error : 'The "Hello" field is required.',
+    }
+
+    let fields = {
+      name: '',
+    }
+
+    let rules = {
+      name: ['required']
+    }
+
+    let errors = {
+      name: {
+        required: 'The "Name" field must be present.'
+      }
+    }
+
+    let failMultiple = {
+      valid  : false,
+      fields : {
+        name : {
+          valid : false,
+          rule  : 'required',
+          error : 'The "Name" field must be present.',
+        },
+      },
+    };
+
+    expect(window.Iodine.assert('', ['required'], {
+      'required': 'The "Hello" field is required.'
+    })).toStrictEqual(fail)
+
+    expect(window.Iodine.assert(fields, rules, errors)).toStrictEqual(failMultiple)
+});


### PR DESCRIPTION
First of all, congratulations for creating this amazing library.

As I have been using Laravel for a long time, I always missed a library that had a similar validation structure, so I found Iodine.

When using it I missed being able to customize the error messages per field, so I added a way to pass an object containing these messages to the assert method.

This pull request contains :

- The edited source code on _**assert**_ and _**_validate**_ functions.
- The test suite associated with it.
- An example associated with it in the README.

I hope this functionality will be useful for the community, as it will be for my specific use case